### PR TITLE
adding Hawaii time zone

### DIFF
--- a/multiclock.js
+++ b/multiclock.js
@@ -11,5 +11,6 @@ setInterval(function() {
     $("#acwst_time").text(local.clone().tz("Australia/Eucla").format("HH:mm"));
     $("#utc_time").text(local.clone().utc().format("HH:mm"));    
     $("#central_europe_time").text(local.clone().tz("Europe/Madrid").format("HH:mm"));
+    $("#hawaii_time").text(local.clone().tz("Pacific/Honolulu").format("HH:mm"));
     $("#epoch_time").text(local.unix());
 }, 1000);


### PR DESCRIPTION
## Why
Adding the Hawaii time zone increases the functionality of the multiclock.js file by supporting an additional region. This is beneficial for users in Hawaii or those who need to track Hawaii Standard Time (HST) alongside other time zones.

## How
Updated the multiclock.js file to include the Hawaii time zone (HST). This involved adding the appropriate time zone offset and ensuring it displays correctly with the other clocks.